### PR TITLE
Fixing a blank page bug

### DIFF
--- a/includes/classes/class-wpmoly-utils.php
+++ b/includes/classes/class-wpmoly-utils.php
@@ -12,6 +12,7 @@
  * @copyright 2014 CaerCam.org
  */
 
+require_once(ABSPATH . 'wp-admin/includes/screen.php');
 if ( ! class_exists( 'WPMOLY_Formatting_Meta' ) )
 	require_once WPMOLY_PATH . '/includes/classes/class-wpmoly-formatting-meta.php';
 if ( ! class_exists( 'WPMOLY_Formatting_Details' ) )


### PR DESCRIPTION
Hi Charlie,
I was having a blank page on the wp-admin pages when I updated the plugin from 1.2 to 2.0-RC1, after setting WP_DEBUG  to
i was having "Fatal error: Call to undefined function get_current_screen() in/cinema/wp-content/plugins/wpmovielibrary-master/includes/classes/class-wpmoly-utils.php on line 921". So i added this line and it fixed the issue.
Thank you for this great update.
