### PR TITLE
The deprecated meta data notice fix

### DIFF
--- a/includes/classes/legacy/class-wpmoly-legacy.php
+++ b/includes/classes/legacy/class-wpmoly-legacy.php
@@ -163,7 +163,8 @@ if ( ! class_exists( 'WPMOLY_Legacy' ) ) :
 					  FROM {$wpdb->postmeta}
 					 WHERE ( meta_key='_wpmoly_movie_tmdb_id'
 					      OR meta_key='_wpmoly_movie_title' )
-					   AND meta_value!='' )"
+					   AND meta_value!='' )
+				    AND post_status = 'publish'"
 			);
 			$movies = ( ! $wpdb->num_rows ? false : $movies );
 


### PR DESCRIPTION
I believe the post id needs to exists in the wp_posts table for post meta to really matter, no point in giving a notice for a post meta where the post doesn't exist.

Please review code first, I'm not 100% sure if the curly brackets should be used like that in the `join` there. First time using curly brackets like that ;/

On my side, no more notice :+1: 
